### PR TITLE
Normalize CI/CD workflows

### DIFF
--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -1,16 +1,17 @@
-# SPDX-FileCopyrightText: 2025 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: 'Approve Dependabot'
+name: 'Dependabot auto approval'
 
 on:
-  pull_request_target
+  pull_request_target:
 
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
-  dependabot:
+  approve:
+    # yamllint disable-line
     uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -1,15 +1,16 @@
 # SPDX-FileCopyrightText: 2025 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: 'Dependabot auto approval'
+name: 'Approve Dependabot'
 
 on:
   pull_request_target
+
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
-  package:
-    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
+  dependabot:
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'Automatically relase patch versions.'
+
+on:
+  schedule: # Run every day at 12:00 UTC
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
+    secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: 2025 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: 'Automatically relase patch versions.'
+name: 'Auto Release'
 
 on:
   schedule: # Run every day at 12:00 UTC
@@ -13,5 +13,6 @@ permissions:
 
 jobs:
   release:
+    # yamllint disable-line
     uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,14 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+  contents: write
+  packages: write
+
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@788c9de035be5d5c99be5917c90355a3f3c2ff0c # v4.4.29
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
       release-type:   library
       yaml-lint-skip: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: CI
@@ -25,6 +25,7 @@ permissions:
 
 jobs:
   ci:
+    # yamllint disable-line
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
       release-type:   library

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,7 +11,12 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+    uses: xmidt-org/.github/.github/workflows/proj-template.yml@1340ff58ac2ad7bfba86fa531784bbd575d4b9b0 # proj-v1
     secrets: inherit

--- a/.github/workflows/proj.yml
+++ b/.github/workflows/proj.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: 'PROJ: xmidt-team'
@@ -17,6 +17,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@1340ff58ac2ad7bfba86fa531784bbd575d4b9b0 # proj-v1
+  proj:
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit


### PR DESCRIPTION
## Summary

This PR normalizes the CI/CD workflows to match the xmidt-org Ideal State as described in issue #58.

## Changes

- **ci.yml**: Added top-level `permissions` block with `pull-requests: read`, `contents: write`, and `packages: write`
- **ci.yml**: Updated shared-go workflow reference from v4.4.29 to v4.9.41 with pinned commit SHA
- **auto-releaser.yml**: Created new workflow file that references `xmidt-org/shared-go/.github/workflows/auto-releaser.yml` with `contents: write` permission
- **approve-dependabot.yml**: Renamed from `dependabot-approver.yml` and updated to reference `xmidt-org/shared-go/.github/workflows/approve-dependabot.yml` with pinned commit SHA
- **proj-xmidt-team.yml**: Added top-level `permissions` block with `contents: read`, `issues: write`, and `pull-requests: write`
- **proj-xmidt-team.yml**: Pinned workflow reference to commit SHA instead of branch reference

All workflow references now use pinned commit SHAs with version comments as required.

Fixes #58